### PR TITLE
Create no soporta gramáticas sensibles al contexto directamente.md

### DIFF
--- a/amigo/no soporta gramáticas sensibles al contexto directamente.md
+++ b/amigo/no soporta gramáticas sensibles al contexto directamente.md
@@ -1,0 +1,57 @@
+En español, una gramática de **NLTK para español** como la que hemos definido es una **gramática libre de contexto (CFG, Context-Free Grammar)** y no es **sensible al contexto (CSG, Context-Sensitive Grammar)**. Veamos por qué.
+
+---
+
+### **¿Por qué no es sensible al contexto?**  
+Una **gramática sensible al contexto (CSG)**, formalmente, es aquella que permite reglas de la forma:
+
+\[
+\alpha A \beta \rightarrow \alpha \gamma \beta, \quad \text{donde } |\gamma| \geq |\alpha|
+\]
+
+Es decir, la transformación de una variable **depende del contexto en el que aparece**. Esto es **más potente** que las gramáticas libres de contexto (CFG), pero **NLTK no las soporta directamente**, ya que requiere reglas más complejas.
+
+Nuestra gramática en NLTK es **libre de contexto (CFG)** porque **todas las reglas** siguen la forma:
+
+\[
+A \rightarrow \alpha
+\]
+
+donde **\( A \)** es un solo símbolo no terminal y **\( \alpha \)** es una secuencia de símbolos terminales y no terminales. **El lado izquierdo de la regla nunca depende de su contexto**, lo que es una característica clave de una gramática libre de contexto.
+
+---
+
+### **Ejemplo de Limitación**
+En español, una **gramática libre de contexto** no puede manejar fácilmente:
+
+✅ **Casos simples manejables con CFG:**
+- *El niño juega en el parque.* → Puede ser generado sin problemas.
+
+❌ **Casos que requieren una gramática sensible al contexto (CSG):**
+- *Los niños juegan en el parque.*  
+  - Aquí, **"niños"** (plural) obliga a que **"juegan"** también esté en plural.
+  - Una **CFG no puede capturar fácilmente esta concordancia de número y persona** sin usar mecanismos adicionales como características (feature-based grammars en NLTK).
+
+---
+
+### **¿Cómo hacer que sea sensible al contexto?**
+Para hacer que la gramática sea **sensible al contexto (CSG)** en español, necesitaríamos:
+
+1. **Etiquetas con características (Feature Structures en NLTK)**
+   - Ejemplo: **Det[número=singular] → "el"**  
+   - Esto permitiría manejar concordancia de número y género.
+
+2. **Gramáticas dependientes del contexto**
+   - Implementadas con **ATN (Augmented Transition Networks)** o **Unificación de rasgos**.
+
+3. **Extender el parser con programación lógica (como Prolog)**
+   - Se puede usar **DCG (Definite Clause Grammar)** en Prolog para modelar dependencias.
+
+---
+
+### **Conclusión**
+- **Nuestra gramática en NLTK es libre de contexto (CFG)** porque sus reglas no dependen del contexto en el que aparecen los símbolos.
+- **El español necesita reglas sensibles al contexto** para manejar adecuadamente concordancia de género y número.
+- **NLTK no soporta gramáticas sensibles al contexto directamente**, pero se pueden hacer aproximaciones usando **features y programación lógica**.
+
+Si quieres extender esta gramática para que sea más precisa, podemos agregar **estructuras de características (feature-based grammars)** en NLTK. 🚀


### PR DESCRIPTION
```markdown
En español, una gramática de **NLTK para español** como la que hemos definido es una **gramática libre de contexto (CFG, Context-Free Grammar)** y no es **sensible al contexto (CSG, Context-Sensitive Grammar)**. Veamos por qué.

---

### **¿Por qué no es sensible al contexto?**  
Una **gramática sensible al contexto (CSG)**, formalmente, es aquella que permite reglas de la forma:

\[
\alpha A \beta \rightarrow \alpha \gamma \beta, \quad \text{donde } |\gamma| \geq |\alpha|
\]

Es decir, la transformación de una variable **depende del contexto en el que aparece**. Esto es **más potente** que las gramáticas libres de contexto (CFG), pero **NLTK no las soporta directamente**, ya que requiere reglas más complejas.

Nuestra gramática en NLTK es **libre de contexto (CFG)** porque **todas las reglas** siguen la forma:

\[
A \rightarrow \alpha
\]

donde **\( A \)** es un solo símbolo no terminal y **\( \alpha \)** es una secuencia de símbolos terminales y no terminales. **El lado izquierdo de la regla nunca depende de su contexto**, lo que es una característica clave de una gramática libre de contexto.

---

### **Ejemplo de Limitación**
En español, una **gramática libre de contexto** no puede manejar fácilmente:

✅ **Casos simples manejables con CFG:**
- *El niño juega en el parque.* → Puede ser generado sin problemas.

❌ **Casos que requieren una gramática sensible al contexto (CSG):**
- *Los niños juegan en el parque.*  
  - Aquí, **"niños"** (plural) obliga a que **"juegan"** también esté en plural.
  - Una **CFG no puede capturar fácilmente esta concordancia de número y persona** sin usar mecanismos adicionales como características (feature-based grammars en NLTK).

---

### **¿Cómo hacer que sea sensible al contexto?**
Para hacer que la gramática sea **sensible al contexto (CSG)** en español, necesitaríamos:

1. **Etiquetas con características (Feature Structures en NLTK)**
   - Ejemplo: **Det[número=singular] → "el"**  
   - Esto permitiría manejar concordancia de número y género.

2. **Gramáticas dependientes del contexto**
   - Implementadas con **ATN (Augmented Transition Networks)** o **Unificación de rasgos**.

3. **Extender el parser con programación lógica (como Prolog)**
   - Se puede usar **DCG (Definite Clause Grammar)** en Prolog para modelar dependencias.

---

### **Conclusión**
- **Nuestra gramática en NLTK es libre de contexto (CFG)** porque sus reglas no dependen del contexto en el que aparecen los símbolos.
- **El español necesita reglas sensibles al contexto** para manejar adecuadamente concordancia de género y número.
- **NLTK no soporta gramáticas sensibles al contexto directamente**, pero se pueden hacer aproximaciones usando **features y programación lógica**.

Si quieres extender esta gramática para que sea más precisa, podemos agregar **estructuras de características (feature-based grammars)** en NLTK. 🚀
```